### PR TITLE
Add SECURITY.md, update rust toolchain version to 1.72.1

### DIFF
--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -31,5 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
-        npm install markdown-link-check
+        # markdown-link-check had a regression introduced in version 3.12.0. Keep it at 3.11.2 until that is resolved
+        # Issue: https://github.com/tcort/markdown-link-check/issues/304
+        npm install markdown-link-check@3.11.2
         find . -type d \( -name node_modules -o -name .github \) -prune -o -type f -name '*.md' -print0 | xargs -0 -n1 node_modules/.bin/markdown-link-check --config ./tools/.markdownlinkcheck.json --quiet

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 [workspace]
+# The default resolver for workspaces is different than for regular packages, so use v2 to avoid warnings
+resolver = "2"
 members = [
     "intent_brokering/dogmode/common",
     "intent_brokering/dogmode/applications/cloud-object-detection",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+This project implements the Eclipse Foundation Security Policy
+
+* <https://www.eclipse.org/security>
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities to the Eclipse Foundation Security Team at
+<security@eclipse.org>

--- a/intent_brokering/dogmode/applications/dog-mode-logic/src/main.rs
+++ b/intent_brokering/dogmode/applications/dog-mode-logic/src/main.rs
@@ -169,6 +169,9 @@ pub async fn main() -> Result<(), Error> {
             expected_properties: &[(&str, Value)],
         ) -> Result<(), Error> {
             let inspection_result = intent_broker.inspect(VDT_NAMESPACE, path).await?;
+
+            // try_fold does not work in this case. It would short-circuit on Error and we only want an Error if all of the entries are Error.
+            #[allow(clippy::manual_try_fold)]
             inspection_result.iter().map(|m| {
                 expected_properties.iter().map(|(expected_key, expected_value)| m.get(*expected_key)
                     .ok_or_else(|| anyhow!("Member does not specify {expected_key:?}."))

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.70"
+channel = "1.72.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Resolves #24 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously there was no Security Policy file. Add one which reflects Eclipse Foundation's security policy and contact.
## Description
<!--- Describe your changes in detail -->
- Adds security policy file pointing to Eclipse foundation's security policy. 
- Updates rust toolchain version to 1.72.1.
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[optional scope]: </description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
